### PR TITLE
Fix setupIonicSvelte import

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	//	import { setupIonicSvelte } from ../lib/ionic/svelte';
 	// import Menu from '$components/Menu.svelte';
 	//	import { pwaStatusStream, type PWAStatus } from '$lib/pwa';
@@ -6,9 +7,18 @@
 	import { prefetch } from '$app/navigation';
 
 	// this gives error -
-	import { setupIonicSvelte } from '$lib/ionic/svelte';
+	// import { setupIonicSvelte } from '$lib/ionic/svelte';
 
 	//	setupIonicSvelte();
+
+	// Prevent FOUC by blocking rendering until ionic is loaded
+	let ionicLoaded = false;
+
+	onMount(async () => {
+		const { setupIonicSvelte } = await import('$lib/ionic/svelte');
+		setupIonicSvelte();
+		ionicLoaded = true;
+	});
 
 	/* Theme variables */
 	import '../theme/variables.css';
@@ -30,10 +40,12 @@
     */
 </script>
 
-<ion-app>
-	<ion-split-pane content-id="main">
-		<div class="ion-page" id="main">
-			<slot />
-		</div>
-	</ion-split-pane>
-</ion-app>
+{#if ionicLoaded}
+	<ion-app>
+		<ion-split-pane content-id="main">
+			<div class="ion-page" id="main">
+				<slot />
+			</div>
+		</ion-split-pane>
+	</ion-app>
+{/if}


### PR DESCRIPTION
Uses await import() onMount. Assumption is there must be something that is executing server-side, and I think svelte-kit still works as if it's in SSR mode whilst in dev. Importing onMount ensures this code is only read client-side.

One side-effect from the above, is that there is FOUC until setupIonicSvelte is executed. A small fix for this is to simply set a `ionicLoaded` variable, to check against, to block rendering until ionic is ready. It isn't ideal, but I think it may be the best we can do.